### PR TITLE
HTTP -> HTTPS

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,8 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ 
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 


### PR DESCRIPTION
Changed HTTP to HTTPS because original GNU GPL v3 license
`Copyright © 2007 Free Software Foundation, Inc. <https://fsf.org/>`

Original license
https://www.gnu.org/licenses/gpl-3.0.en.html