### PR TITLE
Sanitize node names

### DIFF
--- a/web/updateGraph.py
+++ b/web/updateGraph.py
@@ -2,6 +2,7 @@
 from flask import Config
 from database import NodeDB
 import graphPlotter
+import cgi
 
 import urllib, json
 url = "http://y.yakamo.org:3000/current"
@@ -36,6 +37,7 @@ def generate_graph(time_limit=60*60*3):
     for ip in data:
       info = NodeInfo(ip, data[ip][0])
       if len(data[ip]) >= 3: info.label = data[ip][2]
+      info.label = cgi.escape(info.label)
       toAdd.append(info)
 
     nodes = dict()


### PR DESCRIPTION
Apparently pygraphviz doesn't like it when you try to include html in a node label (it crashes).

This runs `cgi.escape` on the node labels, so it should replace obviously bad characters. Another (more thorough) fix can happen later, if there are still cases where it crashes. I guess I need to figure out what pygraphviz can support (or consider switching to another library to do placement, maybe run it in the browser like the tomesh guys are doing?).